### PR TITLE
Update shared library cache after install.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN \
   ./autogen.sh && \
   ./configure && \
   make install && \
-  rm ../varnish-$VARNISH_VERSION.tar.gz
+  rm ../varnish-$VARNISH_VERSION.tar.gz && \
+  ldconfig
 
 COPY start-varnishd.sh /usr/local/bin/start-varnishd
 


### PR DESCRIPTION
When I run `varnishtest` in the latest newsdev/varnish container, I get
an error while loading shared libraries...

```
docker run --rm -ti newsdev/varnish:latest /bin/bash
$ varnishtest
varnishtest: error while loading shared libraries: libvarnishapi.so.1:
cannot open shared object file: No such file or directory
$
```

... the file does appear to be on the system...

```
$ find / -name libvarnishapi.so.1
/usr/local/lib/libvarnishapi.so.1
/usr/local/src/varnish-4.1.0/lib/libvarnishapi/.libs/libvarnishapi.so.1
```

... but, `varnishtest` cannot find it until I run `ldconfig`...

```
$ ldconfig
$ varnishtest
$
```

... special thanks to
https://ma.ttias.be/varnish-varnishhistvarnishtop-error-while-loading-shared-libraries-libvarnishapi-so-1-cannot-open-shared-object-file/
for showing me how to fix the issue.